### PR TITLE
Trusted-artifact-signer OIDC client changes

### DIFF
--- a/keycloak/keycloak-realm-import/templates/keycloak-realmimport.yaml
+++ b/keycloak/keycloak-realm-import/templates/keycloak-realmimport.yaml
@@ -665,7 +665,17 @@ spec:
           backchannel.logout.revoke.offline.tokens": "false"
         authenticationFlowBindingOverrides: {}
         fullScopeAllowed: true
-        nodeReRegistrationTimeout: -1      
+        nodeReRegistrationTimeout: -1   
+          protocolMappers:
+            - id: {{ uuidv4 }}
+              name: "trusted-artifact-signer-audience"
+              protocol: "openid-connect"
+              protocolMapper: "oidc-audience-mapper"
+              consentRequired: false
+              config:
+                included.client.audience: "trusted-artifact-signer"
+                id.token.claim: "false"
+                access.token.claim: "true"   
         defaultClientScopes:
           - profile
           - roles

--- a/keycloak/keycloak-realm-import/templates/keycloak-realmimport.yaml
+++ b/keycloak/keycloak-realm-import/templates/keycloak-realmimport.yaml
@@ -659,23 +659,23 @@ spec:
         frontchannelLogout: true
         protocol: "openid-connect"
         attributes: 
-          oidc.ciba.grant.enabled": "false"
-          oauth2.device.authorization.grant.enabled": "false"
-          backchannel.logout.session.required": "true"
-          backchannel.logout.revoke.offline.tokens": "false"
+          oidc.ciba.grant.enabled: "false"
+          oauth2.device.authorization.grant.enabled: "false"
+          backchannel.logout.session.required: "true"
+          backchannel.logout.revoke.offline.tokens: "false"
         authenticationFlowBindingOverrides: {}
         fullScopeAllowed: true
         nodeReRegistrationTimeout: -1   
-          protocolMappers:
-            - id: {{ uuidv4 }}
-              name: "trusted-artifact-signer-audience"
-              protocol: "openid-connect"
-              protocolMapper: "oidc-audience-mapper"
-              consentRequired: false
-              config:
-                included.client.audience: "trusted-artifact-signer"
-                id.token.claim: "false"
-                access.token.claim: "true"   
+        protocolMappers:
+          - id: {{ uuidv4 }}
+            name: "trusted-artifact-signer-audience"
+            protocol: "openid-connect"
+            protocolMapper: "oidc-audience-mapper"
+            consentRequired: false
+            config:
+              included.client.audience: "trusted-artifact-signer"
+              id.token.claim: "false"
+              access.token.claim: "true"   
         defaultClientScopes:
           - profile
           - roles


### PR DESCRIPTION
The TAS OIDC client (as part of the `keycloak-realmimport.yaml` ) needed some modifications for TAS to accept OIDC access tokens (namely, the tokens need to contain `trusted-artifact-signer` in the `aud:` attribute). Otherwise, fulcio (the TAS certificate authority) will not accept them.

<img width="629" height="440" alt="image" src="https://github.com/user-attachments/assets/37a8250e-a5fe-46fd-99a6-e8a5854ce283" />


I created a new env and ran the ansible playbook from scratch and it works - since the change is localised to the TAS OIDC Client in the realm, there shouldn't be an impact on any other component. 